### PR TITLE
Setup/tailwind with primeng icons

### DIFF
--- a/.postcssrc.json
+++ b/.postcssrc.json
@@ -1,0 +1,5 @@
+{
+  "plugins": {
+    "@tailwindcss/postcss": {}
+  }
+}

--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,10 @@
                 "output": "assets/fonts"
               }
             ],
-            "styles": ["src/styles.css"],
+            "styles": [
+              "src/styles.css",
+              "node_modules/primeicons/primeicons.css"
+            ],
             "scripts": []
           },
           "configurations": {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="card flex justify-center">
-  <p-button label="Check" class="w-52 bg-orange-500 text-center" />
+  <button pButton label="Check" class="w-52 bg-orange-500 text-center"></button>
 </div>
 
 <h1 class="text-3xl font-bold underline">Hello world!</h1>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="card flex justify-center">
-  <button pButton label="Check" class="w-52 bg-orange-500 text-center"></button>
+  <p-button label="Check" styleClass="w-52 bg-orange-500 text-center" />
 </div>
 
 <h1 class="text-3xl font-bold underline">Hello world!</h1>

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,9 +1,9 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { providePrimeNG } from 'primeng/config';
-import Aura from '@primeng/themes/aura';
-import { routes } from './app.routes';
+import { ApplicationConfig, provideZoneChangeDetection } from "@angular/core";
+import { provideRouter } from "@angular/router";
+import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
+import { providePrimeNG } from "primeng/config";
+import Aura from "@primeng/themes/aura";
+import { routes } from "./app.routes";
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -14,11 +14,11 @@ export const appConfig: ApplicationConfig = {
       theme: {
         preset: Aura,
         options: {
-          prefix: 'uebiz',
-          darkModeSelector: 'none',
+          prefix: "uebiz",
+          darkModeSelector: "none",
           cssLayer: {
-            name: 'primeng',
-            order: 'tailwind, primeng',
+            name: "primeng",
+            order: "theme, base, primeng",
           },
         },
       },

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,10 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
-@use "primeicons/primeicons.css";
 @plugin 'tailwindcss-primeui';
 @layer tailwind, primeng;
 
 @layer tailwind {
   @import "tailwindcss";
 }
-@import "tailwindcss-primeui";
-@import "tailwindcss";


### PR DESCRIPTION
- Gets PrimeNG icons working with TailwindCSS (uses this workaround due to compatibility issues with later versions of Angular, PrimeNG, and Tailwind: https://github.com/primefaces/primeicons/issues/1185#issuecomment-2672384224)
- Updates CSS layer order to avoid conflicts with PrimeNG styling and TailwindCSS styling
- Updates example code to demonstrate the use of tailwind styling on PrimeNG components